### PR TITLE
Compact adb logcat output

### DIFF
--- a/emulator-run-cmd/src/emulator.ts
+++ b/emulator-run-cmd/src/emulator.ts
@@ -87,7 +87,7 @@ export class Emulator {
         console.log('Starting logcat read process');
         try {
             await execIgnoreFailure(`mkdir -p artifacts`)
-            await execIgnoreFailure(`bash -c \\\"${this.sdk.androidHome()}/platform-tools/adb -s emulator-${this.adbPort} logcat -v long > artifacts/logcat.log &\"`)
+            await execIgnoreFailure(`bash -c \\\"${this.sdk.androidHome()}/platform-tools/adb -s emulator-${this.adbPort} logcat -dv time > artifacts/logcat.log &\"`)
         } catch (e) {
             console.warn("can't start logcat read process. skipping")
         }


### PR DESCRIPTION
It's about to improve this nice logcat feature.

Currently the adb logcat output looks like this

```
[ 06-14 07:35:25.940  2056: 2138 D/CarDrivingState ]
Property Changed: propId=291504647

[ 06-14 07:35:26.342  2056: 2138 I/chatty   ]
uid=1000(system) VEHICLE-HAL identical 2 lines

[ 06-14 07:35:26.653  1894: 2024 I/GnssLocationProvider ]
WakeLock acquired by sendMessage(REPORT_SV_STATUS, 0, com.android.server.location.GnssLocationProvider$SvStatusInfo@6986c7a)

[ 06-14 07:35:26.654  1894: 1916 I/GnssLocationProvider ]
WakeLock released by handleMessage(REPORT_SV_STATUS, 0, com.android.server.location.GnssLocationProvider$SvStatusInfo@6986c7a)
```
When you do a grep, you don't see time,reason and text in one line, and you have to search manually this blown-up huge file.

With this pull request, it looks like in Andorid Studio and when you do a grep, you see immediate all relevant info in one line. Btw, the file itsn't blown-up anymore

```
06-13 17:14:55.145 I/Telecom ( 1894): DefaultDialerCache: Refreshing default dialer for user 0: now null: DDC.oR@AHg
06-13 17:14:55.161 V/BackupManagerConstants( 1894): getFullBackupIntervalMilliseconds(...) returns 86400000
06-13 17:14:55.166 E/LoadedApk( 1894): Unable to instantiate appComponentFactory
06-13 17:14:55.166 E/LoadedApk( 1894): java.lang.ClassNotFoundException: Didn't find class "androidx.core.app.CoreComponentFactory" on path: DexPathList[[],nativeLibraryDirectories=[/data/app/com.abcgroup.idnext.launcher-siV5_ag8EP-KaqVN44l3qA==/lib/x86_64, /data/app/com.abcgroup.idnext.launcher-siV5_ag8EP-KaqVN44l3qA==/base.apk!/lib/x86_64, /system/lib64]]
06-13 17:14:55.166 E/LoadedApk( 1894): 	at dalvik.system.BaseDexClassLoader.findClass(BaseDexClassLoader.java:134)
06-13 17:14:55.166 E/LoadedApk( 1894): 	at java.lang.ClassLoader.loadClass(ClassLoader.java:379)
06-13 17:14:55.166 E/LoadedApk( 1894): 	at java.lang.ClassLoader.loadClass(ClassLoader.java:312)
06-13 17:14:55.166 E/LoadedApk( 1894): 	at android.app.LoadedApk.createAppFactory(LoadedApk.java:226)
06-13 17:14:55.166 E/LoadedApk( 1894): 	at android.app.LoadedApk.updateApplicationInfo(LoadedApk.java:338)
06-13 17:14:55.166 E/LoadedApk( 1894): 	at android.app.ActivityThread.handleDispatchPackageBroadcast(ActivityThread.java:5388)
06-13 17:14:55.166 E/LoadedApk( 1894): 	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1733)
06-13 17:14:55.166 E/LoadedApk( 1894): 	at android.os.Handler.dispatchMessage(Handler.java:106)
06-13 17:14:55.166 E/LoadedApk( 1894): 	at android.os.Looper.loop(Looper.java:193)
06-13 17:14:55.166 E/LoadedApk( 1894): 	at com.android.server.SystemServer.run(SystemServer.java:454)
06-13 17:14:55.166 E/LoadedApk( 1894): 	at com.android.server.SystemServer.main(SystemServer.java:294)
06-13 17:14:55.166 E/LoadedApk( 1894): 	at java.lang.reflect.Method.invoke(Native Method)
06-13 17:14:55.166 E/LoadedApk( 1894): 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493)
06-13 17:14:55.166 E/LoadedApk( 1894): 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:838)
06-13 17:14:55.287 W/Looper  ( 1894): Drained
06-13 17:14:55.320 I/ActivityManager( 1894): Start proc 20519:com.abcgroup.idnext.navigation/u0a46 for activity com.abcgroup.idnext.navigation/.map.MainActivity
06-13 17:14:55.603 W/ActivityThread(20519): Application com.abcgroup.idnext.navigation is waiting for the debugger on port 8100...
06-13 17:14:55.715 W/Looper  ( 1894): Slow dispatch took 110ms android.ui h=com.android.server.am.ActivityManagerService$UiHandler c=null m=6
```
