### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,17 @@ so they're immutable.
 ```yaml
 steps:
   - uses: actions/checkout@v1
+
+  # Download & install the Android SDK.
   - uses: malinskiy/action-android/install-sdk@release/0.0.7
+
+  # Set up platform tools like adb.
+  - run: sdkmanager platform-tools
+
+  # Start ADB (and verify that pathing is working correctly).
   - run: adb devices
+
+  # Verify $ANDROID_HOME is properly set for later Gradle commands.
   - run: echo $ANDROID_HOME
 ```
 


### PR DESCRIPTION
Clarify the purpose of each step, and add a missing step that's needed for ADB to work correctly (``sdkmanager platform-tools``) per https://github.com/Malinskiy/action-android/blob/5c20fa7/.github/workflows/test-macos.yml#L16 and https://github.com/Malinskiy/action-android/issues/22#issuecomment-636297741.

I noticed this when trying to get https://github.com/oppia/oppia-android/pull/1844 to work.