### PR TITLE
Feature/boot timeout

### DIFF
--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -21,6 +21,7 @@ jobs:
         tag: default
         abi: x86
         cmd: adb shell getprop
+        bootTimeout: 500
     - uses: actions/upload-artifact@v1
       with:
         name: logcat

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ steps:
 - `hardwareProfile` is the hardware profile of the emulator. Check the `avdmanager list` for supported value. I advise to use string names instead of ids since those might change between sdk updates
 - `cmdOptions` is value which you can use to pass additional arguments to the emulator start command. By default this is `-no-snapshot-save -noaudio -no-boot-anim`
 - `disableAnimations` to disable animations using the system preferences. `false` by default. Keep in mind that applications might not respect system settings and these might have no effect at all 
+- `bootTimeout` is the emulator boot timeout (default is 600 seconds = 10 minutes)
 - `verbose` if you want to enable additional logging for this action
 
 ### Artifacts

--- a/emulator-run-cmd/action.yml
+++ b/emulator-run-cmd/action.yml
@@ -23,6 +23,9 @@ inputs:
   hardwareProfile:
     description: 'device profile to use. see avdmanager list for possible options'
     default: ''
+  bootTimeout:
+    description: 'Boot emulator timeout (seconds)'
+    default: '600'
   verbose:
     description: 'be verbose'
     default: 'false'

--- a/emulator-run-cmd/src/emulator.ts
+++ b/emulator-run-cmd/src/emulator.ts
@@ -26,9 +26,9 @@ export class Emulator {
         this.telnetPort = telnetPort;
     }
 
-    async start(cmdOptions: String): Promise<Boolean> {
+    async start(cmdOptions: String, bootTimeout: number): Promise<Boolean> {
         await execIgnoreFailure(`bash -c \\\"${this.sdk.emulatorCmd()} @${this.name} ${cmdOptions} &\"`)
-        let booted = await this.waitForBoot();
+        let booted = await this.waitForBoot(bootTimeout);
         console.log(`booted=${booted}`)
         return booted
     }
@@ -39,8 +39,8 @@ export class Emulator {
         return
     }
 
-    async waitForBoot(): Promise<boolean> {
-        for (let countdown = 300; countdown > 0; countdown--) {
+    async waitForBoot(timeout: number): Promise<boolean> {
+        for (let countdown = timeout; countdown > 0; countdown--) {
             if (countdown == 0) {
                 console.error("Timeout waiting for the emulator")
                 return false

--- a/emulator-run-cmd/src/main.ts
+++ b/emulator-run-cmd/src/main.ts
@@ -51,7 +51,7 @@ async function run() {
 
         let bootTimeout = core.getInput('bootTimeout')
         if (bootTimeout == null) {
-            bootTimeout = 600
+            bootTimeout = '600'
         }
 
         console.log(`Starting emulator with API=${api}, TAG=${tag} and ABI=${abi}...`)
@@ -75,7 +75,7 @@ async function run() {
             let emulator = await sdk.createEmulator("emulator", api, tag, abi, hardwareProfile);
             console.log("starting adb server")
             await sdk.startAdbServer()
-            let booted = await emulator.start(cmdOptions, bootTimeout);
+            let booted = await emulator.start(cmdOptions, +bootTimeout);
             if (!booted) {
                 core.setFailed("emulator boot failed")
                 await emulator.stop()

--- a/emulator-run-cmd/src/main.ts
+++ b/emulator-run-cmd/src/main.ts
@@ -49,6 +49,11 @@ async function run() {
             disableAnimations = true
         }
 
+        let bootTimeout = core.getInput('bootTimeout')
+        if (bootTimeout == null) {
+            bootTimeout = 600
+        }
+
         console.log(`Starting emulator with API=${api}, TAG=${tag} and ABI=${abi}...`)
 
         const androidHome = process.env.ANDROID_HOME
@@ -70,7 +75,7 @@ async function run() {
             let emulator = await sdk.createEmulator("emulator", api, tag, abi, hardwareProfile);
             console.log("starting adb server")
             await sdk.startAdbServer()
-            let booted = await emulator.start(cmdOptions);
+            let booted = await emulator.start(cmdOptions, bootTimeout);
             if (!booted) {
                 core.setFailed("emulator boot failed")
                 await emulator.stop()

--- a/install-sdk/src/emulator.ts
+++ b/install-sdk/src/emulator.ts
@@ -26,9 +26,9 @@ export class Emulator {
         this.telnetPort = telnetPort;
     }
 
-    async start(cmdOptions: String): Promise<Boolean> {
+    async start(cmdOptions: String, bootTimeout: number): Promise<Boolean> {
         await execIgnoreFailure(`bash -c \\\"${this.sdk.emulatorCmd()} @${this.name} ${cmdOptions} &\"`)
-        let booted = await this.waitForBoot();
+        let booted = await this.waitForBoot(bootTimeout);
         console.log(`booted=${booted}`)
         return booted
     }
@@ -39,8 +39,8 @@ export class Emulator {
         return
     }
 
-    async waitForBoot(): Promise<boolean> {
-        for (let countdown = 300; countdown > 0; countdown--) {
+    async waitForBoot(timeout: number): Promise<boolean> {
+        for (let countdown = timeout; countdown > 0; countdown--) {
             if (countdown == 0) {
                 console.error("Timeout waiting for the emulator")
                 return false
@@ -87,7 +87,7 @@ export class Emulator {
         console.log('Starting logcat read process');
         try {
             await execIgnoreFailure(`mkdir -p artifacts`)
-            await execIgnoreFailure(`bash -c \\\"${this.sdk.androidHome()}/platform-tools/adb -s emulator-${this.adbPort} logcat -v long > artifacts/logcat.log &\"`)
+            await execIgnoreFailure(`bash -c \\\"${this.sdk.androidHome()}/platform-tools/adb -s emulator-${this.adbPort} logcat -dv time > artifacts/logcat.log &\"`)
         } catch (e) {
             console.warn("can't start logcat read process. skipping")
         }


### PR DESCRIPTION
Due to flaky emulator startup, the only option is to control boot timeout