### PR TITLE
Update Node.js from v12 to v16 for Apple M1 support

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -6,10 +6,10 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: test install-sdk
-      run: npm config delete prefix && source ~/.nvm/nvm.sh && nvm install v12.10.0 && npm install && npm ci && npm run build
+      run: npm config delete prefix && source ~/.nvm/nvm.sh && nvm install v16.15.0 && npm install && npm ci && npm run build
       working-directory: install-sdk
     - name: test emulator-run-cmd
-      run: npm config delete prefix && source ~/.nvm/nvm.sh && nvm install v12.10.0 && npm install && npm ci && npm run build
+      run: npm config delete prefix && source ~/.nvm/nvm.sh && nvm install v16.15.0 && npm install && npm ci && npm run build
       working-directory: emulator-run-cmd
     - uses: ./install-sdk
       name: install sdk

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -6,10 +6,10 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: test install-sdk
-      run: npm config delete prefix && source ~/.nvm/nvm.sh && nvm install v12.10.0 && npm install && npm ci && npm run build
+      run: npm config delete prefix && source ~/.nvm/nvm.sh && nvm install v16.15.0 && npm install && npm ci && npm run build
       working-directory: install-sdk
     - name: test emulator-run-cmd
-      run: npm config delete prefix && source ~/.nvm/nvm.sh && nvm install v12.10.0 && npm install && npm ci && npm run build
+      run: npm config delete prefix && source ~/.nvm/nvm.sh && nvm install v16.15.0 && npm install && npm ci && npm run build
       working-directory: emulator-run-cmd
     - uses: ./install-sdk
       name: install sdk

--- a/emulator-run-cmd/action.yml
+++ b/emulator-run-cmd/action.yml
@@ -30,5 +30,5 @@ inputs:
     description: 'be verbose'
     default: 'false'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'lib/main.js'

--- a/emulator-run-cmd/package-lock.json
+++ b/emulator-run-cmd/package-lock.json
@@ -1249,9 +1249,9 @@
       }
     },
     "@types/node": {
-      "version": "12.12.14",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.14.tgz",
-      "integrity": "sha512-u/SJDyXwuihpwjXy7hOOghagLEV1KdAST6syfnOk6QZAMzZuWZqXy5aYYZbh8Jdpd4escVFP0MvftHNDb9pruA==",
+      "version": "16.10.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.10.0.tgz",
+      "integrity": "sha512-In+/vAdT+kkHigDSN9lUDDmzsIyKn5efDcwmGGnBtZVHnBv1oDVn6vC0ckic9FxSm+X0BGJGECpI1ZOg60E21g==",
       "dev": true
     },
     "@types/normalize-package-data": {

--- a/emulator-run-cmd/package.json
+++ b/emulator-run-cmd/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@types/jest": "^24.0.23",
-    "@types/node": "^12.12.14",
+    "@types/node": "^16.10.0",
     "jest": "^25.5.4",
     "jest-circus": "^25.5.4",
     "ts-jest": "^25.4.0",

--- a/install-sdk/action.yml
+++ b/install-sdk/action.yml
@@ -9,5 +9,5 @@ inputs:
     description: 'do you accept all current Android licenses?'
     default: 'yes'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'lib/main.js'

--- a/install-sdk/package-lock.json
+++ b/install-sdk/package-lock.json
@@ -1249,9 +1249,9 @@
       }
     },
     "@types/node": {
-      "version": "12.12.14",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.14.tgz",
-      "integrity": "sha512-u/SJDyXwuihpwjXy7hOOghagLEV1KdAST6syfnOk6QZAMzZuWZqXy5aYYZbh8Jdpd4escVFP0MvftHNDb9pruA==",
+      "version": "16.10.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.10.0.tgz",
+      "integrity": "sha512-In+/vAdT+kkHigDSN9lUDDmzsIyKn5efDcwmGGnBtZVHnBv1oDVn6vC0ckic9FxSm+X0BGJGECpI1ZOg60E21g==",
       "dev": true
     },
     "@types/normalize-package-data": {

--- a/install-sdk/package.json
+++ b/install-sdk/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@types/jest": "^24.0.13",
-    "@types/node": "^12.0.4",
+    "@types/node": "^16.10.0",
     "jest": "^25.5.4",
     "jest-circus": "^25.5.4",
     "ts-jest": "^25.4.0",

--- a/prepare-for-release.sh
+++ b/prepare-for-release.sh
@@ -3,5 +3,5 @@
 set -ex
 
 for i in emulator-run-cmd install-sdk; do
-  (cd $i && docker run -it -v $(pwd):/opt/app -w /opt/app node:12 bash -c 'npm install && npm run build && npm prune --production' && git add -f node_modules lib)
+  (cd $i && docker run -it -v $(pwd):/opt/app -w /opt/app node:16 bash -c 'npm install && npm run build && npm prune --production' && git add -f node_modules lib)
 done


### PR DESCRIPTION
According to the release policy of Node.js,
Node.js v12 reached EOL (end-of-life).

https://nodejs.org/en/about/releases/

I think ruby/setup-ruby is ready to update Node.js to v16
because GitHub Actions runners support v16.

actions/runner#772

An I hope this action runs now on a Apple Silicon M1.
close #57