### PR TITLE
Reduce CI builds on forks

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -1,5 +1,10 @@
 name: "Test Linux"
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
 jobs:
   test:
     runs-on: ubuntu-18.04

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -1,5 +1,10 @@
 name: "Test macOS"
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
 jobs:
   test:
     runs-on: macOS-10.15


### PR DESCRIPTION
When you run pull requests on forks you run jobs twice
<img width="585" alt="image" src="https://user-images.githubusercontent.com/3314607/177030509-003c2140-4212-4851-9b6e-df1379bb496c.png">

This pull request helps