### PR TITLE
Bump android sdk for mac

### DIFF
--- a/emulator-run-cmd/lib/sdk.js
+++ b/emulator-run-cmd/lib/sdk.js
@@ -179,7 +179,7 @@ class LinuxAndroidSdk extends BaseAndroidSdk {
 class MacOSAndroidSdk extends BaseAndroidSdk {
     constructor() {
         super(...arguments);
-        this.defaultSdkUrl = "https://dl.google.com/android/repository/commandlinetools-mac-6858069_latest.zip";
+        this.defaultSdkUrl = "https://dl.google.com/android/repository/commandlinetools-mac-9477386_latest.zip";
     }
 }
 class SdkFactory {

--- a/emulator-run-cmd/src/sdk.ts
+++ b/emulator-run-cmd/src/sdk.ts
@@ -174,7 +174,7 @@ class LinuxAndroidSdk extends BaseAndroidSdk {
 }
 
 class MacOSAndroidSdk extends BaseAndroidSdk {
-    defaultSdkUrl = "https://dl.google.com/android/repository/commandlinetools-mac-6858069_latest.zip"
+    defaultSdkUrl = "https://dl.google.com/android/repository/commandlinetools-mac-9477386_latest.zip"
 }
 
 export class SdkFactory {

--- a/install-sdk/lib/sdk.js
+++ b/install-sdk/lib/sdk.js
@@ -180,7 +180,7 @@ class LinuxAndroidSdk extends BaseAndroidSdk {
 class MacOSAndroidSdk extends BaseAndroidSdk {
     constructor() {
         super(...arguments);
-        this.defaultSdkUrl = "https://dl.google.com/android/repository/commandlinetools-mac-6858069_latest.zip";
+        this.defaultSdkUrl = "https://dl.google.com/android/repository/commandlinetools-mac-9477386_latest.zip";
     }
 }
 class SdkFactory {

--- a/install-sdk/src/sdk.ts
+++ b/install-sdk/src/sdk.ts
@@ -175,7 +175,7 @@ class LinuxAndroidSdk extends BaseAndroidSdk {
 }
 
 class MacOSAndroidSdk extends BaseAndroidSdk {
-    defaultSdkUrl = "https://dl.google.com/android/repository/commandlinetools-mac-6858069_latest.zip"
+    defaultSdkUrl = "https://dl.google.com/android/repository/commandlinetools-mac-9477386_latest.zip"
 }
 
 export class SdkFactory {


### PR DESCRIPTION
Maybe this solve #70

You use version 3.0, currently there is `10.0-beta04` out there.
<img width="1247" alt="image" src="https://user-images.githubusercontent.com/3314607/234255497-6d875a01-9c62-4f92-83cc-ce3170d194d6.png">

