### PR TITLE
Update Node.js from v16 to v20 (#84)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,7 @@ jobs:
         tag: default
         abi: x86
         cmd: adb shell getprop
+        cmdOptions: -noaudio -no-boot-anim -no-window
         bootTimeout: 500
     - uses: actions/upload-artifact@v1
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,10 +11,10 @@ jobs:
         distribution: 'temurin'
         java-version: '17'
     - name: test install-sdk
-      run: npm config delete prefix && source ~/.nvm/nvm.sh && nvm install v16.15.0 && npm install && npm ci && npm run build
+      run: npm config delete prefix && source ~/.nvm/nvm.sh && nvm install v20.14.0 && npm install && npm ci && npm run build
       working-directory: install-sdk
     - name: test emulator-run-cmd
-      run: npm config delete prefix && source ~/.nvm/nvm.sh && nvm install v16.15.0 && npm install && npm ci && npm run build
+      run: npm config delete prefix && source ~/.nvm/nvm.sh && nvm install v20.14.0 && npm install && npm ci && npm run build
       working-directory: emulator-run-cmd
     - uses: ./install-sdk
       name: install sdk
@@ -46,10 +46,10 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
       - name: test install-sdk
-        run: npm config delete prefix && source ~/.nvm/nvm.sh && nvm install v16.15.0 && npm install && npm ci && npm run build
+        run: npm config delete prefix && source ~/.nvm/nvm.sh && nvm install v20.14.0 && npm install && npm ci && npm run build
         working-directory: install-sdk
       - name: test emulator-run-cmd
-        run: npm config delete prefix && source ~/.nvm/nvm.sh && nvm install v16.15.0 && npm install && npm ci && npm run build
+        run: npm config delete prefix && source ~/.nvm/nvm.sh && nvm install v20.14.0 && npm install && npm ci && npm run build
         working-directory: emulator-run-cmd
       - uses: ./install-sdk
         name: install sdk

--- a/emulator-run-cmd/action.yml
+++ b/emulator-run-cmd/action.yml
@@ -30,5 +30,5 @@ inputs:
     description: 'be verbose'
     default: 'false'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'lib/main.js'

--- a/emulator-run-cmd/package-lock.json
+++ b/emulator-run-cmd/package-lock.json
@@ -14,7 +14,7 @@
       },
       "devDependencies": {
         "@types/jest": "^28.1.4",
-        "@types/node": "^16.10.0",
+        "@types/node": "^20.12.12",
         "jest": "^28.1.2",
         "jest-circus": "^28.1.2",
         "ts-jest": "^28.0.5",
@@ -1063,10 +1063,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "16.11.43",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.43.tgz",
-      "integrity": "sha512-GqWykok+3uocgfAJM8imbozrqLnPyTrpFlrryURQlw1EesPUCx5XxTiucWDSFF9/NUEXDuD4bnvHm8xfVGWTpQ==",
-      "dev": true
+      "version": "20.12.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.12.tgz",
+      "integrity": "sha512-eWLDGF/FOSPtAvEqeRAQ4C8LSA7M1I7i0ky1I8U7kD1J5ITyW3AsRhQrKVoWf5pFKZ2kILsEGJhsI9r93PYnOw==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/prettier": {
       "version": "2.6.3",
@@ -3400,6 +3403,12 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.4.tgz",
@@ -4378,10 +4387,13 @@
       }
     },
     "@types/node": {
-      "version": "16.11.43",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.43.tgz",
-      "integrity": "sha512-GqWykok+3uocgfAJM8imbozrqLnPyTrpFlrryURQlw1EesPUCx5XxTiucWDSFF9/NUEXDuD4bnvHm8xfVGWTpQ==",
-      "dev": true
+      "version": "20.12.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.12.tgz",
+      "integrity": "sha512-eWLDGF/FOSPtAvEqeRAQ4C8LSA7M1I7i0ky1I8U7kD1J5ITyW3AsRhQrKVoWf5pFKZ2kILsEGJhsI9r93PYnOw==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~5.26.4"
+      }
     },
     "@types/prettier": {
       "version": "2.6.3",
@@ -6106,6 +6118,12 @@
       "version": "4.7.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
       "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "dev": true
+    },
+    "undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true
     },
     "update-browserslist-db": {

--- a/emulator-run-cmd/package.json
+++ b/emulator-run-cmd/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@types/jest": "^28.1.4",
-    "@types/node": "^16.10.0",
+    "@types/node": "^20.12.12",
     "jest": "^28.1.2",
     "jest-circus": "^28.1.2",
     "ts-jest": "^28.0.5",

--- a/install-sdk/action.yml
+++ b/install-sdk/action.yml
@@ -9,5 +9,5 @@ inputs:
     description: 'do you accept all current Android licenses?'
     default: 'yes'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'lib/main.js'

--- a/install-sdk/package-lock.json
+++ b/install-sdk/package-lock.json
@@ -14,7 +14,7 @@
       },
       "devDependencies": {
         "@types/jest": "^28.1.4",
-        "@types/node": "^16.10.0",
+        "@types/node": "^20.12.12",
         "jest": "^28.1.2",
         "jest-circus": "^28.1.2",
         "ts-jest": "^28.0.5",
@@ -1063,10 +1063,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "16.11.43",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.43.tgz",
-      "integrity": "sha512-GqWykok+3uocgfAJM8imbozrqLnPyTrpFlrryURQlw1EesPUCx5XxTiucWDSFF9/NUEXDuD4bnvHm8xfVGWTpQ==",
-      "dev": true
+      "version": "20.12.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.12.tgz",
+      "integrity": "sha512-eWLDGF/FOSPtAvEqeRAQ4C8LSA7M1I7i0ky1I8U7kD1J5ITyW3AsRhQrKVoWf5pFKZ2kILsEGJhsI9r93PYnOw==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/prettier": {
       "version": "2.6.3",
@@ -3400,6 +3403,12 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.4.tgz",
@@ -4378,10 +4387,13 @@
       }
     },
     "@types/node": {
-      "version": "16.11.43",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.43.tgz",
-      "integrity": "sha512-GqWykok+3uocgfAJM8imbozrqLnPyTrpFlrryURQlw1EesPUCx5XxTiucWDSFF9/NUEXDuD4bnvHm8xfVGWTpQ==",
-      "dev": true
+      "version": "20.12.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.12.tgz",
+      "integrity": "sha512-eWLDGF/FOSPtAvEqeRAQ4C8LSA7M1I7i0ky1I8U7kD1J5ITyW3AsRhQrKVoWf5pFKZ2kILsEGJhsI9r93PYnOw==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~5.26.4"
+      }
     },
     "@types/prettier": {
       "version": "2.6.3",
@@ -6106,6 +6118,12 @@
       "version": "4.7.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
       "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "dev": true
+    },
+    "undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true
     },
     "update-browserslist-db": {

--- a/install-sdk/package.json
+++ b/install-sdk/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@types/jest": "^28.1.4",
-    "@types/node": "^16.10.0",
+    "@types/node": "^20.12.12",
     "jest": "^28.1.2",
     "jest-circus": "^28.1.2",
     "ts-jest": "^28.0.5",

--- a/prepare-for-release.sh
+++ b/prepare-for-release.sh
@@ -3,5 +3,5 @@
 set -ex
 
 for i in emulator-run-cmd install-sdk; do
-  (cd $i && docker run -it -v $(pwd):/opt/app -w /opt/app node:16 bash -c 'npm install && npm run build && npm prune --production' && git add -f node_modules lib)
+  (cd $i && docker run -it -v $(pwd):/opt/app -w /opt/app node:20 bash -c 'npm install && npm run build && npm prune --production' && git add -f node_modules lib)
 done


### PR DESCRIPTION
* Update Node.js from v16 to v20

According to the release policy of Node.js,
Node.js v16 reached EOL (end-of-life).

https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/